### PR TITLE
Improved sample driver

### DIFF
--- a/pkg/driver.go
+++ b/pkg/driver.go
@@ -15,6 +15,8 @@ package pkg
 
 import (
 	"context"
+
+	"sigs.k8s.io/cosi-driver-sample/pkg/s3"
 )
 
 func NewDriver(ctx context.Context, provisioner string) (*IdentityServer, *DriverServer, error) {
@@ -22,5 +24,6 @@ func NewDriver(ctx context.Context, provisioner string) (*IdentityServer, *Drive
 			provisioner: provisioner,
 		}, &DriverServer{
 			provisioner: provisioner,
+			client:      s3.NewClient(),
 		}, nil
 }

--- a/pkg/provisioner.go
+++ b/pkg/provisioner.go
@@ -18,11 +18,14 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 	cosi "sigs.k8s.io/container-object-storage-interface-spec"
+	"sigs.k8s.io/cosi-driver-sample/pkg/s3"
 )
 
 type DriverServer struct {
 	provisioner string
+	client      *s3.FakeS3Client
 }
 
 // DriverCreateBucket is an idempotent method for creating buckets
@@ -38,8 +41,26 @@ type DriverServer struct {
 //	non-nil err -           Internal error                                [requeue'd with exponential backoff]
 func (s *DriverServer) DriverCreateBucket(ctx context.Context,
 	req *cosi.DriverCreateBucketRequest) (*cosi.DriverCreateBucketResponse, error) {
+	bucketName := req.GetName()
+	parameters := req.GetParameters()
 
-	return nil, status.Error(codes.Unimplemented, "DriverCreateBucket: not implemented")
+	if s.client.BucketExists(bucketName) {
+		if s.client.IsBucketEqual(bucketName, parameters) {
+			klog.InfoS("Bucket with the same parameters already exists, no error", "name", bucketName)
+			return &cosi.DriverCreateBucketResponse{BucketId: bucketName}, nil
+		} else {
+			klog.InfoS("Bucket already exists", "name", bucketName)
+			return nil, status.Errorf(codes.AlreadyExists, "Bucket already exists: %s", bucketName)
+		}
+	}
+
+	err := s.client.CreateBucket(bucketName, parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.InfoS("Successfully created bucket", "name", bucketName)
+	return &cosi.DriverCreateBucketResponse{BucketId: bucketName}, nil
 }
 
 // DriverDeleteBucket is an idempotent method for deleting buckets
@@ -52,8 +73,11 @@ func (s *DriverServer) DriverCreateBucket(ctx context.Context,
 //	non-nil err -           Internal error                                [requeue'd with exponential backoff]
 func (s *DriverServer) DriverDeleteBucket(ctx context.Context,
 	req *cosi.DriverDeleteBucketRequest) (*cosi.DriverDeleteBucketResponse, error) {
+	bucketId := req.GetBucketId()
 
-	return nil, status.Error(codes.Unimplemented, "DriverCreateBucket: not implemented")
+	s.client.DeleteBucket(bucketId)
+	klog.InfoS("Successfully deleted bucket", "name", bucketId)
+	return &cosi.DriverDeleteBucketResponse{}, nil
 }
 
 // DriverCreateBucketAccess is an idempotent method for creating bucket access
@@ -65,8 +89,25 @@ func (s *DriverServer) DriverDeleteBucket(ctx context.Context,
 //	non-nil err -           Internal error                                [requeue'd with exponential backoff]
 func (s *DriverServer) DriverGrantBucketAccess(ctx context.Context,
 	req *cosi.DriverGrantBucketAccessRequest) (*cosi.DriverGrantBucketAccessResponse, error) {
+	name := req.GetName()
 
-	return nil, status.Error(codes.Unimplemented, "DriverCreateBucket: not implemented")
+	access, err := s.client.CreateBucketAccess(req.GetBucketId(), name)
+	if err != nil {
+		return nil, err
+	}
+
+	klog.InfoS("Successfully grant access", "name", access.Name, "accessKeyID", access.AccessKeyID)
+	return &cosi.DriverGrantBucketAccessResponse{
+		AccountId: access.Name,
+		Credentials: map[string]*cosi.CredentialDetails{
+			"s3": &cosi.CredentialDetails{
+				Secrets: map[string]string{
+					"accessKeyID":     access.AccessKeyID,
+					"accessSecretKey": access.AccessSecretKey,
+				},
+			},
+		},
+	}, nil
 }
 
 // DriverDeleteBucketAccess is an idempotent method for deleting bucket access
@@ -79,6 +120,10 @@ func (s *DriverServer) DriverGrantBucketAccess(ctx context.Context,
 //	non-nil err -           Internal error                                [requeue'd with exponential backoff]
 func (s *DriverServer) DriverRevokeBucketAccess(ctx context.Context,
 	req *cosi.DriverRevokeBucketAccessRequest) (*cosi.DriverRevokeBucketAccessResponse, error) {
+	bucketId := req.GetBucketId()
+	accountId := req.GetAccountId()
 
-	return nil, status.Error(codes.Unimplemented, "DriverCreateBucket: not implemented")
+	s.client.DeleteBucketAccess(bucketId, accountId)
+	klog.InfoS("Successfully revoke access", "bucketName", bucketId, "account", accountId)
+	return &cosi.DriverRevokeBucketAccessResponse{}, nil
 }

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -1,0 +1,88 @@
+package s3
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+type User struct {
+	Name            string
+	AccessKeyID     string
+	AccessSecretKey string
+}
+
+type Bucket struct {
+	Parameters map[string]string
+}
+
+// FakeS3Client is a reference implementation S3 client
+// that use k-v store as a bucket.
+type FakeS3Client struct {
+	Buckets  map[string]*Bucket
+	Accesses map[string]string
+}
+
+// NewClient creates new S3 client.
+func NewClient() *FakeS3Client {
+	return &FakeS3Client{
+		Buckets:  map[string]*Bucket{},
+		Accesses: map[string]string{},
+	}
+}
+
+// genKey generates random string of lenght n.
+func genKey(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// CreateBucket creates a bucket.
+func (s *FakeS3Client) CreateBucket(name string, parameters map[string]string) error {
+	s.Buckets[name] = &Bucket{
+		Parameters: parameters,
+	}
+
+	return nil
+}
+
+// BucketExists checks if bucket already exists.
+func (s *FakeS3Client) BucketExists(name string) bool {
+	_, ok := s.Buckets[name]
+	return ok
+}
+
+// IsBucketEqual check equality with new bucket.
+func (s *FakeS3Client) IsBucketEqual(name string, parameters map[string]string) bool {
+	return reflect.DeepEqual(s.Buckets[name].Parameters, parameters)
+}
+
+// DeleteBucket deletes a bucket.
+func (s *FakeS3Client) DeleteBucket(name string) {
+	delete(s.Buckets, name)
+}
+
+// CreateBucketAccess creates a bucket access object.
+func (s *FakeS3Client) CreateBucketAccess(bucketName, name string) (*User, error) {
+	if !s.BucketExists(bucketName) {
+		return nil, fmt.Errorf("CreateBucketAccess: Bucket does not exists %s", bucketName)
+	}
+
+	s.Accesses[name] = bucketName
+
+	return &User{
+		Name:            name,
+		AccessKeyID:     genKey(20),
+		AccessSecretKey: genKey(40),
+	}, nil
+}
+
+// DeleteBucketAccess deletes a bucket acces object.
+func (s *FakeS3Client) DeleteBucketAccess(bucketName, name string) {
+	delete(s.Accesses, name)
+}


### PR DESCRIPTION
This PR extends functionality of current sample driver. Currently sample driver return error for every gRPC call. This change implements simple client which stores bucket and access to the bucket as maps.