### PR TITLE
ci: add loop device OSD support to CI setup

### DIFF
--- a/hack/setup-s3-backend.sh
+++ b/hack/setup-s3-backend.sh
@@ -47,6 +47,13 @@ USER_SECRET="rook-ceph-object-user-${OBJECT_STORE}-${OBJECT_USER}"
 
 OUT_CREDS_FILE="${OUT_CREDS_FILE:-${PWD}/s3-credentials.yaml}"
 
+# When true, Rook is configured to discover /dev/loop* devices and the
+# CephCluster's storage.deviceFilter is scoped to loop devices only. Used by
+# the COSI Prow CI, where OSDs are backed by loop-mounted files on a kind
+# node (see hack/setup-kind.sh in the container-object-storage-interface
+# repo). Default false: real disks should not opt into loop discovery.
+LOOP_DEVICE_OSDS="${LOOP_DEVICE_OSDS:-false}"
+
 # ---------------------------------------------------------------------------
 # Apply everything up front. CRDs must land first (server-side) so the
 # CephCluster/CephObjectStore/CephObjectStoreUser objects are recognized; the
@@ -60,7 +67,24 @@ echo "==> Applying Rook common/operator/csi-operator + CephCluster + CephObjectS
 kubectl apply -f "${ROOK_RAW_BASE}/common.yaml"
 kubectl apply --server-side -f "${ROOK_RAW_BASE}/csi-operator.yaml"
 kubectl apply -f "${ROOK_RAW_BASE}/operator.yaml"
-kubectl apply -f "${ROOK_RAW_BASE}/cluster-test.yaml"
+
+if [ "${LOOP_DEVICE_OSDS}" = "true" ]; then
+  # ROOK_CEPH_ALLOW_LOOP_DEVICES: Rook skips loop devices by default; the
+  # operator config toggle opts back in.
+  kubectl -n "${ROOK_NS}" patch configmap rook-ceph-operator-config \
+    --type merge \
+    -p '{"data":{"ROOK_CEPH_ALLOW_LOOP_DEVICES":"true"}}'
+
+  # deviceFilter: the upstream cluster-test.yaml uses useAllDevices: true,
+  # which would grab every /dev/[sh]d? on the runner too. Scope OSD
+  # discovery to loop devices only so the runner's system disk is untouched.
+  curl --fail --location --silent "${ROOK_RAW_BASE}/cluster-test.yaml" \
+    | sed '/useAllDevices: true/a\    deviceFilter: "^loop[0-9]+$"' \
+    | kubectl apply -f -
+else
+  kubectl apply -f "${ROOK_RAW_BASE}/cluster-test.yaml"
+fi
+
 kubectl apply -f "${ROOK_RAW_BASE}/object-test.yaml"
 kubectl apply -f "${ROOK_DIR}/object-user.yaml"
 

--- a/hack/setup-s3-backend.sh
+++ b/hack/setup-s3-backend.sh
@@ -47,7 +47,8 @@ USER_SECRET="rook-ceph-object-user-${OBJECT_STORE}-${OBJECT_USER}"
 
 OUT_CREDS_FILE="${OUT_CREDS_FILE:-${PWD}/s3-credentials.yaml}"
 
-LOOP_DEVICE_NAMES="${LOOP_DEVICE_NAMES:-}"
+LOOP_DEVICE_OSDS="${LOOP_DEVICE_OSDS:-false}"
+LOOP_DEVICE_BACKING_DIR="${LOOP_DEVICE_BACKING_DIR:-}"
 
 # ---------------------------------------------------------------------------
 # Apply everything up front. CRDs must land first (server-side) so the
@@ -63,7 +64,23 @@ kubectl apply -f "${ROOK_RAW_BASE}/common.yaml"
 kubectl apply --server-side -f "${ROOK_RAW_BASE}/csi-operator.yaml"
 kubectl apply -f "${ROOK_RAW_BASE}/operator.yaml"
 
-if [ -n "${LOOP_DEVICE_NAMES}" ]; then
+if [ "${LOOP_DEVICE_OSDS}" = "true" ]; then
+  [ -n "${LOOP_DEVICE_BACKING_DIR}" ] || {
+    echo "LOOP_DEVICE_BACKING_DIR is required when LOOP_DEVICE_OSDS=true" >&2
+    exit 1
+  }
+
+  loop_devices=()
+  for disk in "${LOOP_DEVICE_BACKING_DIR}"/ceph-osd-*.img; do
+    loop_device=$(losetup -j "${disk}" | cut -d: -f1)
+    [ -n "${loop_device}" ] || {
+      echo "no loop device found for ${disk}" >&2
+      exit 1
+    }
+    loop_devices+=("${loop_device}")
+  done
+  LOOP_DEVICE_NAMES=$(IFS=,; echo "${loop_devices[*]}")
+
   kubectl -n "${ROOK_NS}" patch configmap rook-ceph-operator-config \
     --type merge \
     -p '{"data":{"ROOK_CEPH_ALLOW_LOOP_DEVICES":"true"}}'

--- a/hack/setup-s3-backend.sh
+++ b/hack/setup-s3-backend.sh
@@ -47,12 +47,7 @@ USER_SECRET="rook-ceph-object-user-${OBJECT_STORE}-${OBJECT_USER}"
 
 OUT_CREDS_FILE="${OUT_CREDS_FILE:-${PWD}/s3-credentials.yaml}"
 
-# When true, Rook is configured to discover /dev/loop* devices and the
-# CephCluster's storage.deviceFilter is scoped to loop devices only. Used by
-# the COSI Prow CI, where OSDs are backed by loop-mounted files on a kind
-# node (see hack/setup-kind.sh in the container-object-storage-interface
-# repo). Default false: real disks should not opt into loop discovery.
-LOOP_DEVICE_OSDS="${LOOP_DEVICE_OSDS:-false}"
+LOOP_DEVICE_NAMES="${LOOP_DEVICE_NAMES:-}"
 
 # ---------------------------------------------------------------------------
 # Apply everything up front. CRDs must land first (server-side) so the
@@ -68,18 +63,22 @@ kubectl apply -f "${ROOK_RAW_BASE}/common.yaml"
 kubectl apply --server-side -f "${ROOK_RAW_BASE}/csi-operator.yaml"
 kubectl apply -f "${ROOK_RAW_BASE}/operator.yaml"
 
-if [ "${LOOP_DEVICE_OSDS}" = "true" ]; then
-  # ROOK_CEPH_ALLOW_LOOP_DEVICES: Rook skips loop devices by default; the
-  # operator config toggle opts back in.
+if [ -n "${LOOP_DEVICE_NAMES}" ]; then
   kubectl -n "${ROOK_NS}" patch configmap rook-ceph-operator-config \
     --type merge \
     -p '{"data":{"ROOK_CEPH_ALLOW_LOOP_DEVICES":"true"}}'
 
-  # deviceFilter: the upstream cluster-test.yaml uses useAllDevices: true,
-  # which would grab every /dev/[sh]d? on the runner too. Scope OSD
-  # discovery to loop devices only so the runner's system disk is untouched.
   curl --fail --location --silent "${ROOK_RAW_BASE}/cluster-test.yaml" \
-    | sed '/useAllDevices: true/a\    deviceFilter: "^loop[0-9]+$"' \
+    | awk -v devices="${LOOP_DEVICE_NAMES}" '
+        /^[[:space:]]+useAllDevices: true$/ {
+          print "    useAllDevices: false"
+          print "    devices:"
+          count = split(devices, names, ",")
+          for (i = 1; i <= count; i++) print "      - name: " names[i]
+          next
+        }
+        { print }
+      ' \
     | kubectl apply -f -
 else
   kubectl apply -f "${ROOK_RAW_BASE}/cluster-test.yaml"

--- a/hack/setup-s3-backend.sh
+++ b/hack/setup-s3-backend.sh
@@ -50,6 +50,27 @@ OUT_CREDS_FILE="${OUT_CREDS_FILE:-${PWD}/s3-credentials.yaml}"
 LOOP_DEVICE_OSDS="${LOOP_DEVICE_OSDS:-false}"
 LOOP_DEVICE_BACKING_DIR="${LOOP_DEVICE_BACKING_DIR:-}"
 
+run_as_root() {
+  if (( EUID == 0 )); then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+ensure_udev_data() {
+  local dev_file
+  local major_minor
+  local data_file
+
+  run_as_root mkdir -p /run/udev/data
+  for dev_file in /sys/class/block/*/dev; do
+    read -r major_minor < "${dev_file}"
+    data_file="/run/udev/data/b${major_minor}"
+    [ -e "${data_file}" ] || run_as_root touch "${data_file}"
+  done
+}
+
 # ---------------------------------------------------------------------------
 # Apply everything up front. CRDs must land first (server-side) so the
 # CephCluster/CephObjectStore/CephObjectStoreUser objects are recognized; the
@@ -70,6 +91,7 @@ if [ "${LOOP_DEVICE_OSDS}" = "true" ]; then
     exit 1
   }
 
+  ensure_udev_data
   loop_devices=()
   for disk in "${LOOP_DEVICE_BACKING_DIR}"/ceph-osd-*.img; do
     loop_device=$(losetup -j "${disk}" | cut -d: -f1)


### PR DESCRIPTION
Adds a LOOP_DEVICE_OSDS toggle and updates the sample setup to configure, discover, and expose udev metadata for loop-backed OSD devices.